### PR TITLE
FMT compile improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
             run: |
                 pip3 install conan
                 conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
-                conan install . -s build_type=Debug
+                conan install . -s build_type=Debug --build=missing
           - name: Build the file
             run: |
                 cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_CONAN=ON .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ IF (WIN32)
     ADD_DEFINITIONS("-DPolyChat_EXPORT")
 ENDIF (WIN32)
 
+# Make FMT build header-only to make dependencies easier
+target_compile_definitions(libmatrix-client PUBLIC FMT_HEADER_ONLY)
+target_compile_definitions(libmatrix-client-static PUBLIC FMT_HEADER_ONLY)
+
 if(USE_CONAN)
     include(${CMAKE_CURRENT_SOURCE_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS)
@@ -98,11 +102,11 @@ else()
     endif()
 
     find_package(fmt CONFIG REQUIRED)
-    target_link_libraries(libmatrix-client PRIVATE fmt::fmt fmt::fmt-header-only)
-    target_link_libraries(libmatrix-client-static PRIVATE fmt::fmt fmt::fmt-header-only)
+    target_link_libraries(libmatrix-client PRIVATE fmt::fmt)
+    target_link_libraries(libmatrix-client-static PRIVATE fmt::fmt)
     if(BUILD_DRIVERS)
-        target_link_libraries(driver-static PRIVATE fmt::fmt fmt::fmt-header-only)
-        target_link_libraries(driver-shared PRIVATE fmt::fmt fmt::fmt-header-only)
+        target_link_libraries(driver-static PRIVATE fmt::fmt)
+        target_link_libraries(driver-shared PRIVATE fmt::fmt)
     endif()
 endif()
 

--- a/src/MatrixSession.cpp
+++ b/src/MatrixSession.cpp
@@ -8,7 +8,7 @@
 #include <ctime>
 
 #include <nlohmann/json.hpp>
-#include <fmt/core.h>  // Ignore CPPLintBear
+#include <fmt/format.h>  // Ignore CPPLintBear
 
 #include "MatrixSession.h"
 #include "HTTP.h"

--- a/src/utils/UserUtils.cpp
+++ b/src/utils/UserUtils.cpp
@@ -1,5 +1,5 @@
 #include <nlohmann/json.hpp>
-#include <fmt/core.h> // Ignore CPPLintBear
+#include <fmt/format.h> // Ignore CPPLintBear
 
 #include "MatrixSession.h"
 #include "Users.h"


### PR DESCRIPTION
These changes were needed to support more platforms, and to make compiling easier.

- Ubuntu did not support the `fmt::fmt-header-only` linking target.
- Made it do header-only linkage, which makes it so we don't need to deal with fmt in the libs that use this.

Changing core to format was needed to make it work header-only.