### PR TITLE
Save and add a getter for the user ID

### DIFF
--- a/include/libmatrix-client/MatrixSession.h
+++ b/include/libmatrix-client/MatrixSession.h
@@ -49,6 +49,7 @@ private:
 	std::unique_ptr<HTTPClient> http;
 	std::string homeserverURL;
 	std::string accessToken;
+	std::string userID;
 	std::string deviceID;
 	std::string syncToken;
 
@@ -71,6 +72,8 @@ public:
 
 	std::future<void> LIBMATRIX_DLL_EXPORT updateReadReceipt(std::string roomID, LibMatrix::Message message);
 	std::future<std::vector<User>> LIBMATRIX_DLL_EXPORT getRoomMembers(std::string roomID);
+
+	std::string getUserID();
 };// End MatrixSession Class
 
 }  // namespace LibMatrix

--- a/src/MatrixSession.cpp
+++ b/src/MatrixSession.cpp
@@ -25,11 +25,13 @@ void MatrixSession::setHTTPCaller() {
 	http = std::make_unique<HTTPClient>(homeserverURL);
 }
 
-MatrixSession::MatrixSession() : homeserverURL(""), syncToken("") {
+MatrixSession::MatrixSession() : MatrixSession("") {
 	setHTTPCaller();
 }
 
-MatrixSession::MatrixSession(std::string url) : homeserverURL(url), syncToken("") {
+MatrixSession::MatrixSession(std::string url)
+	: homeserverURL(url), syncToken(""), userID("unknown")
+{
 	setHTTPCaller();
 }
 
@@ -64,6 +66,7 @@ std::future<void> MatrixSession::login(std::string uname, std::string password) 
 		case HTTPStatus::HTTP_OK:
 			accessToken = body["access_token"].get<std::string>();
 			deviceID = body["device_id"].get<std::string>();
+			userID = body["user_id"].get<std::string>();
 			threadResult->set_value();
 			break;
 		default:
@@ -261,4 +264,8 @@ std::future<std::vector<User>> MatrixSession::getRoomMembers(std::string roomID)
 	}
 
 	return threadedResult->get_future();
+}
+
+std::string MatrixSession::getUserID() {
+	return userID;
 }

--- a/src/MatrixSession.cpp
+++ b/src/MatrixSession.cpp
@@ -25,9 +25,7 @@ void MatrixSession::setHTTPCaller() {
 	http = std::make_unique<HTTPClient>(homeserverURL);
 }
 
-MatrixSession::MatrixSession() : MatrixSession("") {
-	setHTTPCaller();
-}
+MatrixSession::MatrixSession() : MatrixSession("") {}
 
 MatrixSession::MatrixSession(std::string url)
 		: homeserverURL(url), syncToken(""), userID("unknown") {

--- a/src/MatrixSession.cpp
+++ b/src/MatrixSession.cpp
@@ -30,8 +30,7 @@ MatrixSession::MatrixSession() : MatrixSession("") {
 }
 
 MatrixSession::MatrixSession(std::string url)
-	: homeserverURL(url), syncToken(""), userID("unknown")
-{
+		: homeserverURL(url), syncToken(""), userID("unknown") {
 	setHTTPCaller();
 }
 


### PR DESCRIPTION
The core & polytrix had no way of knowing the user ID without assumptions, so I saved the user ID from the login result.